### PR TITLE
Coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ if (BUILD_WITH_PROFILING)
   message(STATUS "Profiling enabled")
   set(PROFILING_FLAGS
     "--coverage"
+		"-I${CMAKE_SOURCE_DIR}/overrides/include"
   )
   foreach (f ${PROFILING_FLAGS})
     SVCOMP_SANITIZE_FLAG_NAME(sanitized_name "${f}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ if (BUILD_WITH_PROFILING)
   message(STATUS "Profiling enabled")
   set(PROFILING_FLAGS
     "--coverage"
-		"-I${CMAKE_SOURCE_DIR}/overrides/include"
+    "-I${CMAKE_SOURCE_DIR}/overrides/include"
   )
   foreach (f ${PROFILING_FLAGS})
     SVCOMP_SANITIZE_FLAG_NAME(sanitized_name "${f}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,6 @@ if (BUILD_WITH_PROFILING)
   message(STATUS "Profiling enabled")
   set(PROFILING_FLAGS
     "--coverage"
-    # TODO: Use -fprofile-dir ?
   )
   foreach (f ${PROFILING_FLAGS})
     SVCOMP_SANITIZE_FLAG_NAME(sanitized_name "${f}")

--- a/cmake/add_benchmark.cmake
+++ b/cmake/add_benchmark.cmake
@@ -62,13 +62,24 @@ macro(add_benchmark BENCHMARK_DIR)
       endforeach()
     endif()
 
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} "${SVCB_DIR}/tools/svcb-emit-cmake-decls.py"
-                            ${INPUT_FILE}
-                            --architecture ${SVCOMP_ARCHITECTURE}
-                            --output ${OUTPUT_FILE}
-                            ${_handler_args}
-                    RESULT_VARIABLE RESULT_CODE
-                   )
+    if (BUILD_WITH_PROFILING)
+      execute_process(COMMAND ${PYTHON_EXECUTABLE} "${SVCB_DIR}/tools/svcb-emit-cmake-decls.py"
+                              ${INPUT_FILE}
+                              --architecture ${SVCOMP_ARCHITECTURE}
+                              --output ${OUTPUT_FILE}
+                              --coverage
+                              ${_handler_args}
+                      RESULT_VARIABLE RESULT_CODE
+                     )
+		else()
+      execute_process(COMMAND ${PYTHON_EXECUTABLE} "${SVCB_DIR}/tools/svcb-emit-cmake-decls.py"
+                              ${INPUT_FILE}
+                              --architecture ${SVCOMP_ARCHITECTURE}
+                              --output ${OUTPUT_FILE}
+                              ${_handler_args}
+                      RESULT_VARIABLE RESULT_CODE
+                     )
+		endif()
     if (NOT ${RESULT_CODE} EQUAL 0)
       # Remove the generated output file because it is broken and if we don't
       # the next time configure runs it will succeed.

--- a/coverage.py
+++ b/coverage.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+import argparse
+from collections import namedtuple
+import glob
+import os, os.path
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as xmltree
+
+def mkyamlfuncs():
+	from yaml import load, dump
+	try:
+		from yaml import CLoader as Loader, CDumper as Dumper
+	except ImportError:
+		from yaml import Loader, Dumper
+	return lambda x: load(x, Loader=Loader), lambda x: dump(x, Dumper=Dumper)
+yamlLoad, yamlDump = mkyamlfuncs()
+
+def copytree(src, dst, symlinks = False, ignore = None):
+	"""copy a directory tree, merging with existing target where necessary
+	taken from http://stackoverflow.com/a/22331852/65678"""
+	if not os.path.exists(dst):
+		os.makedirs(dst)
+		shutil.copystat(src, dst)
+	lst = os.listdir(src)
+	if ignore:
+		excl = ignore(src, lst)
+		lst = [x for x in lst if x not in excl]
+	for item in lst:
+		s = os.path.join(src, item)
+		d = os.path.join(dst, item)
+		if symlinks and os.path.islink(s):
+			if os.path.lexists(d):
+				os.remove(d)
+			os.symlink(os.readlink(s), d)
+			try:
+				st = os.lstat(s)
+				mode = stat.S_IMODE(st.st_mode)
+				os.lchmod(d, mode)
+			except:
+				pass # lchmod not available
+		elif os.path.isdir(s):
+			copytree(s, d, symlinks, ignore)
+		else:
+			shutil.copy2(s, d)
+
+PathInfo = namedtuple("PathInfo", ["name", "exe", "cov", "gcno", "gcda", "tests"])
+def pathalyze(bcroot, covroot, bc, wd):
+	name = os.path.relpath(bc, start=bcroot)[:-3]
+	exe = os.path.join(covroot, name)
+	head, tail = os.path.split(exe)
+	gcno = os.path.join(head, "CMakeFiles", tail + ".dir")
+	cov = exe + ".cov"
+	gcda = os.path.join(cov, os.path.relpath(gcno, start = covroot))
+	tests = glob.iglob(glob.escape(os.path.join(wd, "test")) + "*.ktest")
+	return PathInfo(name = name[13:-7], exe = exe, cov = cov, gcno = gcno, gcda = gcda, tests = tests)
+
+def prep(paths, verbose = False):
+	if os.path.isdir(paths.cov):
+		if verbose:
+			print("deleting ", paths.cov, "...", sep="")
+		shutil.rmtree(paths.cov)
+	os.makedirs(paths.cov)
+
+def runall(paths, kleeLibrary, verbose = False):
+	if verbose:
+		print("Running tests for ", paths.name, "...", sep="")
+	for test in paths.tests:
+		env = os.environ.copy()
+		env["LD_LIBRARY_PATH"] = kleeLibrary
+		env["KTEST_FILE"] = test
+		if verbose:
+			print("running test ", test, "...", sep="")
+		name = os.path.basename(test)
+		with open(os.path.join(paths.cov, name + ".out"), "w") as out, open(os.path.join(paths.cov, name + ".err"), "w") as err:
+			proc = subprocess.Popen([paths.exe], env=env, cwd=os.path.split(paths.exe)[0], stdout = out, stderr = err)
+			proc.wait(60)
+
+def analyze(paths, verbose = False):
+	with tempfile.TemporaryDirectory(prefix = "coverage-") as tempdir:
+		if verbose:
+			print("Copying gcov files to ", tempdir, "...", sep="")
+		copytree(paths.gcno, tempdir)
+		copytree(paths.gcda, tempdir)
+		call = ["gcovr", "-r", tempdir, "-f", "/", "-x"]
+		if verbose:
+			print("calling ", call, "...", sep="")
+		proc = subprocess.run(call, stdout = subprocess.PIPE, check = True)
+		if verbose:
+			sys.stdout.write(proc.stdout.decode(sys.stdout.encoding))
+		branchrate = float(xmltree.fromstring(proc.stdout).attrib["branch-rate"])
+		return branchrate
+
+def doit(paths, kleeLibrary, verbose = False):
+	prep(paths, verbose)
+	runall(paths, kleeLibrary, verbose)
+	if os.path.isdir(os.path.join(paths.cov, "benchmarks")): # FIXME
+		branchiness = analyze(paths)
+	else:
+		branchiness = 0.0
+	print("Branch coverage is ", branchiness, " for ", paths.name, sep="")
+	if verbose:
+		print()
+	return branchiness
+
+def main(argv):
+	parser = argparse.ArgumentParser()
+	parser.add_argument("-v", "--verbose", help="increase output verbosity", action="store_true")
+	parser.add_argument("-o", "--output", help="path to output file", default="coverage_report.yml")
+	requiredNamed = parser.add_argument_group('required named arguments')
+	requiredNamed.add_argument("--bc", help="the path to the root of where you built the bytecode files", required=True)
+	requiredNamed.add_argument("--cov", help="the path to the root of where you built the coverage binaries", required=True)
+	requiredNamed.add_argument("--yaml", help="the path to the yaml file that was generated for your KLEE run", required=True)
+	requiredNamed.add_argument("--kleelib", help="the path to your KLEE library directory", required=True)
+	args = parser.parse_args(argv)
+
+	with open(args.output, "w") as out:
+		out.write("results:\n")
+		with open(args.yaml) as f:
+			testspec = yamlLoad(f)
+		for result in testspec["results"]:
+			paths = pathalyze(os.path.realpath(args.bc), os.path.realpath(args.cov), result["invocation_info"]["program"], result["klee_dir"])
+			branchiness = doit(paths, os.path.realpath(args.kleelib), args.verbose)
+			out.write("- program: {}\n  branch_coverage: {:14f}\n".format(paths.name, branchiness))
+
+if __name__ == "__main__":
+	main(sys.argv[1:])

--- a/overrides/include/assert.h
+++ b/overrides/include/assert.h
@@ -6,7 +6,7 @@ void __gcov_flush();
 void __assert_fail(char const* assertion, char const* file, unsigned int line, char const* function);
 #define assert(expr)                                          \
 	do {                                                        \
-		if(expr) {                                                \
+		if(!(expr)) {                                             \
 			__gcov_flush();                                         \
 			__assert_fail(#expr, __FILE__, __LINE__, __func__);     \
 		}                                                         \

--- a/overrides/include/assert.h
+++ b/overrides/include/assert.h
@@ -1,0 +1,14 @@
+#undef assert
+#ifdef NDEBUG
+#define assert(ignore) ((void)0)
+#else
+void __gcov_flush();
+void __assert_fail(char const* assertion, char const* file, unsigned int line, char const* function);
+#define assert(expr)                                          \
+	do {                                                        \
+		if(expr) {                                                \
+			__gcov_flush();                                         \
+			__assert_fail(#expr, __FILE__, __LINE__, __func__);     \
+		}                                                         \
+	} while(0)
+#endif 

--- a/svcb/svcb/build.py
+++ b/svcb/svcb/build.py
@@ -252,19 +252,14 @@ endif()
             declStr += "  {}\n".format(macroName)
         declStr += ")\n"
       # Emit compiler flags
+      declStr += "{indent}target_compile_options({target_name} PRIVATE ${{SVCOMP_STD_{lang_ver}}}".format(
+        indent = cmakeIndent,
+        target_name = targetName,
+        lang_ver = lang_ver
+      )
       if coverage:
-        declStr += "{indent}target_compile_options({target_name} PRIVATE ${{SVCOMP_STD_{lang_ver}}} \"-fprofile-dir={profile_dir}.cov\")\n".format(
-          indent = cmakeIndent,
-          target_name = targetName,
-          lang_ver = lang_ver,
-          profile_dir = targetName
-        )
-      else:
-        declStr += "{indent}target_compile_options({target_name} PRIVATE ${{SVCOMP_STD_{lang_ver}}})\n".format(
-          indent = cmakeIndent,
-          target_name = targetName,
-          lang_ver = lang_ver
-        )
+        declStr +=  " \"-fprofile-dir={profile_dir}.cov\"".format(
+      declStr += ")\n"
 
       # Emit dependency code that adds necessary dependencies to that target
       for (_, depAddDecl) in dependencyHandlingCMakeDecls:

--- a/svcb/svcb/build.py
+++ b/svcb/svcb/build.py
@@ -258,7 +258,7 @@ endif()
         lang_ver = lang_ver
       )
       if coverage:
-        declStr +=  " \"-fprofile-dir={profile_dir}.cov\"".format(
+        declStr +=  " \"-fprofile-dir={profile_dir}.cov\"".format(profile_dir = targetName)
       declStr += ")\n"
 
       # Emit dependency code that adds necessary dependencies to that target

--- a/svcb/svcb/build.py
+++ b/svcb/svcb/build.py
@@ -159,7 +159,7 @@ class CMakeDependencyDispatcher(object):
     return result
 
 cmakeIndent = "  "
-def generateCMakeDecls(benchmarkObjs, sourceRootDir, supportedArchitecture, dependencyDispatcher):
+def generateCMakeDecls(benchmarkObjs, sourceRootDir, supportedArchitecture, dependencyDispatcher, coverage):
   """
     Returns a string containing CMake declarations
     that declare the benchmarks in the list ``benchmarkObjs``.
@@ -252,12 +252,19 @@ endif()
             declStr += "  {}\n".format(macroName)
         declStr += ")\n"
       # Emit compiler flags
-      declStr += "{indent}target_compile_options({target_name} PRIVATE ${{SVCOMP_STD_{lang_ver}}})\n".format(
-        indent=cmakeIndent,
-        target_name=targetName,
-        lang_ver= lang_ver,
-        arch = arch.upper()
-      )
+      if coverage:
+        declStr += "{indent}target_compile_options({target_name} PRIVATE ${{SVCOMP_STD_{lang_ver}}} \"-fprofile-dir={profile_dir}.cov\")\n".format(
+          indent = cmakeIndent,
+          target_name = targetName,
+          lang_ver = lang_ver,
+          profile_dir = targetName
+        )
+      else:
+        declStr += "{indent}target_compile_options({target_name} PRIVATE ${{SVCOMP_STD_{lang_ver}}})\n".format(
+          indent = cmakeIndent,
+          target_name = targetName,
+          lang_ver = lang_ver
+        )
 
       # Emit dependency code that adds necessary dependencies to that target
       for (_, depAddDecl) in dependencyHandlingCMakeDecls:

--- a/svcb/tools/svcb-emit-cmake-decls.py
+++ b/svcb/tools/svcb-emit-cmake-decls.py
@@ -41,6 +41,7 @@ def main(args):
                       default=[],
                       nargs='+',
                       help='Additional dependency handlers to load')
+  parser.add_argument('--coverage', action="store_true")
 
 
   pArgs = parser.parse_args()
@@ -78,7 +79,8 @@ def main(args):
   cmakeDeclStr = svcb.build.generateCMakeDecls(benchmarkObjs,
                                                sourceRootDir=sourceFileDirectory,
                                                supportedArchitecture=pArgs.architecture,
-                                               dependencyDispatcher=dispatcher)
+                                               dependencyDispatcher=dispatcher,
+                                               coverage=pArgs.coverage)
   pArgs.output.write(cmakeDeclStr)
   return 0
 


### PR DESCRIPTION
This is the promised coverage support. I am not sure that coverage is always computed as we want it to (e.g. the parts where we use a library that is hooked into the build scripts), and analysis of programs that are aborted as part of their execution (e.g. via assert) seems to require gcov trickery. Finally, it relies on the fact that we do only perform validation via assertions, as it will obviously result in incorrect summaries if execution continues after performing a technically invalid memory op.

We also still need to decide how we want to do the analysis of the results (e.g. I encountered an invalid example that causes an invalid `klee_assume` to be done, which we can find in the resulting data).

This pull request utilizes [gcovr](http://gcovr.com/) to deal with the precision problem we discussed in the last meeting, which can be installed from the AUR. It also required our klee's `runtime/Runtest/intrinsics.c` to be modified to ignore `model_version`.